### PR TITLE
Makefile.gpyutils: enable .dot file for 3.12

### DIFF
--- a/Makefile.gpyutils
+++ b/Makefile.gpyutils
@@ -19,7 +19,7 @@ upgr_txt = $(upgr_base) $(upgr_streq)
 upgr_dot = $(patsubst %.txt,%.dot,$(upgr_txt))
 upgr_svg = $(patsubst %.dot,%.svg,$(upgr_dot))
 # add new impls here if not stable yet, to avoid insanely huge generation times
-upgr_all = $(upgr_txt) $(upgr_dot) $(upgr_svg) $(outdir)/311-to-312.txt
+upgr_all = $(upgr_txt) $(upgr_dot) $(upgr_svg) $(outdir)/311-to-312.txt $(outdir)/311-to-312.dot
 
 all = $(upgr_all)
 


### PR DESCRIPTION
The .dot file can be useful as it provides detailed graphical information, even when a final .svg has not been generated. This could be beneficial for anyone who wants to access this information without having to generate the complete .svg.